### PR TITLE
Automatically retrieve public SSH key from Ansible host

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -38,10 +38,6 @@ openshift_is_ansible_host: yes
 # (or commands will be ran multiple times).
 openshift_is_master_host: yes
 
-# Deploy SSH key for master host
-# TODO: collect the public key automatically - two step procedure for now
-openshift_ssh_public_key: 'ssh-rsa ...'
-
 # IP or FQDN of the Ansible master (used to restrict the SSH key)
 openshift_ssh_from: 0.0.0.0/0
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -37,7 +37,3 @@ openshift_is_ansible_host: yes
 # If you deploy multiple masters, only mark the first one
 # (or commands will be ran multiple times).
 openshift_is_master_host: yes
-
-# IP or FQDN of the Ansible master (used to restrict the SSH key)
-openshift_ssh_from: 0.0.0.0/0
-

--- a/tasks/ansible.yml
+++ b/tasks/ansible.yml
@@ -16,3 +16,13 @@
   command: ssh-keygen -b 2048 -t rsa -f /root/.ssh/id_rsa -q -N ""
   args:
     creates: /root/.ssh/id_rsa
+
+- name: Retrieve SSH public key
+  slurp:
+    src: /root/.ssh/id_rsa.pub
+  register: ansible_public_key_slurp
+
+- name: Save SSH public key to dummy host
+  add_host:
+    name: OPENSHIFT_ANSIBLE_HOST
+    public_key: "{{ ansible_public_key_slurp.content | b64decode }}"

--- a/tasks/ansible.yml
+++ b/tasks/ansible.yml
@@ -22,7 +22,10 @@
     src: /root/.ssh/id_rsa.pub
   register: ansible_public_key_slurp
 
-- name: Save SSH public key to dummy host
-  add_host:
-    name: OPENSHIFT_ANSIBLE_HOST
+- name: Save SSH public key to fact
+  set_fact:
     public_key: "{{ ansible_public_key_slurp.content | b64decode }}"
+
+- name: Create group of Ansible hosts
+  group_by:
+    key: openshift_ansible_hosts

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,6 +7,8 @@
     # TODO: run Ansible deployment on the host and wait for it to complete
   when: openshift_is_ansible_host
 
+- import_tasks: node.yml
+
 - block:
   - import_tasks: ansible-dir.yml
   - import_tasks: users.yml
@@ -17,5 +19,3 @@
 - import_tasks: localstorage-dirs.yml
   when: openshift_localstorage_enabled
 
-- import_tasks: node.yml
-  when: not openshift_is_ansible_host

--- a/tasks/node.yml
+++ b/tasks/node.yml
@@ -2,6 +2,12 @@
 
 - name: SSH keys
   authorized_key:
-    key: "{{ openshift_ssh_public_key }}"
+    key: "{{ hostvars['OPENSHIFT_ANSIBLE_HOST']['public_key'] }}"
     user: root
     key_options: 'from="{{ openshift_ssh_from }}"'
+  when: hostvars['OPENSHIFT_ANSIBLE_HOST']['public_key'] is defined
+
+- name: SSH key warning
+  debug:
+    msg: SSH key not added to node because the Ansible host wasn't included in the run
+  when: hostvars['OPENSHIFT_ANSIBLE_HOST']['public_key'] is not defined

--- a/tasks/node.yml
+++ b/tasks/node.yml
@@ -2,12 +2,8 @@
 
 - name: SSH keys
   authorized_key:
-    key: "{{ hostvars['OPENSHIFT_ANSIBLE_HOST']['public_key'] }}"
+    key: "{{ hostvars[item]['public_key'] }}"
     user: root
-    key_options: 'from="{{ openshift_ssh_from }}"'
-  when: hostvars['OPENSHIFT_ANSIBLE_HOST']['public_key'] is defined
-
-- name: SSH key warning
-  debug:
-    msg: SSH key not added to node because the Ansible host wasn't included in the run
-  when: hostvars['OPENSHIFT_ANSIBLE_HOST']['public_key'] is not defined
+    key_options: from="{{ hostvars[item]['ansible_default_ipv4']['address'] }}"
+  with_items: "{{ groups['openshift_ansible_hosts'] }}"
+  when: "'openshift_ansible_hosts' in groups and item != inventory_hostname"

--- a/tasks/node.yml
+++ b/tasks/node.yml
@@ -5,5 +5,5 @@
     key: "{{ hostvars[item]['public_key'] }}"
     user: root
     key_options: from="{{ hostvars[item]['ansible_default_ipv4']['address'] }}"
-  with_items: "{{ groups['openshift_ansible_hosts'] }}"
+  loop: "{{ groups['openshift_ansible_hosts'] }}"
   when: "'openshift_ansible_hosts' in groups and item != inventory_hostname"


### PR DESCRIPTION
Caveat: The Ansible host needs to be included in the run to retrieve the public key. If not included, a warning message will be printed.